### PR TITLE
Remove deprecated (vibrate)

### DIFF
--- a/app/src/main/java/com/dmitrybrant/modelviewer/gvr/ModelGvrActivity.java
+++ b/app/src/main/java/com/dmitrybrant/modelviewer/gvr/ModelGvrActivity.java
@@ -3,7 +3,6 @@ package com.dmitrybrant.modelviewer.gvr;
 import android.content.Context;
 import android.opengl.GLES20;
 import android.opengl.Matrix;
-import android.os.Vibrator;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -70,13 +69,11 @@ public class ModelGvrActivity extends GvrActivity implements GvrView.StereoRende
     private float[] headRotation = new float[4];
     private float[] headEulerAngles = new float[3];
 
-    private Vibrator vibrator;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         initializeGvrView();
-        vibrator = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
     }
 
     public void initializeGvrView() {
@@ -204,7 +201,6 @@ public class ModelGvrActivity extends GvrActivity implements GvrView.StereoRende
         Log.i(TAG, "onCardboardTrigger");
         // TODO: use for something
 
-        vibrator.vibrate(50);
     }
 
     // TODO: use for something.


### PR DESCRIPTION
Previously it gave an error on compilation: 'Recompile with -Xlint:deprecation', it worked on my phone (android API 22) but I think that it's better if it is changed.

If you do want to vibrate the phone (as I understood it was trying to do) I could find a new way to make it without deprecated tools.
