### PR TITLE
fix read binary ply color

### DIFF
--- a/app/src/main/java/com/dmitrybrant/modelviewer/ply/PlyModel.kt
+++ b/app/src/main/java/com/dmitrybrant/modelviewer/ply/PlyModel.kt
@@ -492,11 +492,11 @@ class PlyModel(inputStream: InputStream) : IndexedModel() {
             centerMassZ += z.toDouble()
 
             if (useColorBuffer) {
-                colors.add(tempBytes[rOffset].toInt().toFloat() / 255f)
-                colors.add(tempBytes[rOffset].toInt().toFloat() / 255f)
-                colors.add(tempBytes[rOffset].toInt().toFloat() / 255f)
+                colors.add((tempBytes[rOffset].toInt() and 0xff).toFloat() / 255f)
+                colors.add((tempBytes[gOffset].toInt() and 0xff).toFloat() / 255f)
+                colors.add((tempBytes[bOffset].toInt() and 0xff).toFloat() / 255f)
                 if (alphaOffset >= 0) {
-                    colors.add(tempBytes[alphaOffset].toInt().toFloat() / 255f)
+                    colors.add((tempBytes[alphaOffset].toInt()and 0xff).toFloat() / 255f)
                 } else {
                     colors.add(255f)
                 }


### PR DESCRIPTION
Thank you for providing the 3D file read-write code. I used it to display the model file perfectly. I really appreciate it. During my use, I found a small issue where the color information was not correctly read when reading binary format PLY files. After researching the issue, I found that it was due to a missing sign in front of the color float type. I have submitted a new pull request with a fix which you can review. I created a new branch called 'file' and placed a binary PLY file in the asset directory